### PR TITLE
Add support for `str` and `int` Enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code
+.vscode

--- a/COVERAGE.txt
+++ b/COVERAGE.txt
@@ -2,6 +2,6 @@ Name                            Stmts   Miss  Cover
 ---------------------------------------------------
 src/sparkdantic/__init__.py         5      0   100%
 src/sparkdantic/generation.py      37      0   100%
-src/sparkdantic/model.py          111      0   100%
+src/sparkdantic/model.py          124      0   100%
 ---------------------------------------------------
-TOTAL                             153      0   100%
+TOTAL                             166      0   100%

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ class MyModel(SparkModel):
     hobbies: List[str]
 ```
 
+> ℹ️ `Enum`s are supported but they must be mixed with either `int` (`IntEnum` in Python ≥ 3.10) or `str` (`StrEnum`, in Python ≥ 3.11) built-in types:
+
+```python
+from enum import Enum
+
+class Switch(int, Enum):
+    OFF = 0
+    ON = 1
+
+class MyEnumModel(SparkModel):
+    switch: Switch
+```
+
 ### Generating a PySpark Schema
 
 Pydantic has existing models for generating json schemas (with `model_json_schema`). With a `SparkModel` you can 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/mitchelllisle/sparkdantic/graph/badge.svg?token=O6PPQX4FEX)](https://codecov.io/gh/mitchelllisle/sparkdantic)
 [![PyPI version](https://badge.fury.io/py/sparkdantic.svg)](https://badge.fury.io/py/sparkdantic)
 
-> 1️⃣ version: 0.11.0
+> 1️⃣ version: 0.12.0
 
 > ✍️ author: Mitchell Lisle
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ named `SparkModel` that extends the Pydantic's `BaseModel`.
 This module aims to have a small dependency footprint:
 - `pydantic`
 - `pyspark`
-- Python's built-in `datetime`, `decimal`, `enum`, `types`, and `typing` modules
+- Python's built-in `datetime`, `decimal`, `types`, and `typing` modules
 
 ## Usage
 
@@ -39,19 +39,6 @@ class MyModel(SparkModel):
     name: str
     age: int
     hobbies: List[str]
-```
-
-> ℹ️ `Enum`s are supported but they must be mixed with either `int` (`IntEnum` in Python ≥ 3.10) or `str` (`StrEnum`, in Python ≥ 3.11) built-in types:
-
-```python
-from enum import Enum
-
-class Switch(int, Enum):
-    OFF = 0
-    ON = 1
-
-class MyEnumModel(SparkModel):
-    switch: Switch
 ```
 
 ### Generating a PySpark Schema

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ named `SparkModel` that extends the Pydantic's `BaseModel`.
 This module aims to have a small dependency footprint:
 - `pydantic`
 - `pyspark`
-- Python's built-in `datetime`, `decimal`, `types`, and `typing` modules
+- Python's built-in `datetime`, `decimal`, `enum`, `types`, and `typing` modules
 
 ## Usage
 
@@ -39,6 +39,19 @@ class MyModel(SparkModel):
     name: str
     age: int
     hobbies: List[str]
+```
+
+> ℹ️ `Enum`s are supported but they must be mixed with either `int` (`IntEnum` in Python ≥ 3.10) or `str` (`StrEnum`, in Python ≥ 3.11) built-in types:
+
+```python
+from enum import Enum
+
+class Switch(int, Enum):
+    OFF = 0
+    ON = 1
+
+class MyEnumModel(SparkModel):
+    switch: Switch
 ```
 
 ### Generating a PySpark Schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sparkdantic"
-version = "0.11.0"
+version = "0.12.0"
 description = "A pydantic -> spark schema library"
 authors = ["Mitchell Lisle <m.lisle90@gmail.com>"]
 readme = "README.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.12.0
 commit = True
 tag = True
 

--- a/src/sparkdantic/__init__.py
+++ b/src/sparkdantic/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.11.0'
+__version__ = '0.12.0'
 __author__ = 'Mitchell Lisle'
 __email__ = 'm.lisle90@gmail.com'
 

--- a/tests/test_dict_types.py
+++ b/tests/test_dict_types.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from enum import IntEnum
 from typing import Dict
 
 from pyspark.sql.types import (
@@ -20,6 +21,11 @@ from pyspark.sql.types import (
 from sparkdantic.model import SparkModel
 
 
+class IntTestEnum(IntEnum):
+    X = 1
+    Y = 2
+
+
 class DictValuesModel(SparkModel):
     s: Dict[int, int]
     t: Dict[float, float]
@@ -30,6 +36,7 @@ class DictValuesModel(SparkModel):
     bb: Dict[date, date]
     ff: Dict[datetime, datetime]
     jj: Dict[timedelta, timedelta]
+    kk: Dict[IntTestEnum, IntTestEnum]
 
 
 def test_dict_values():
@@ -46,6 +53,7 @@ def test_dict_values():
             StructField(
                 'jj', MapType(DayTimeIntervalType(0, 3), DayTimeIntervalType(0, 3), False), False
             ),
+            StructField('kk', MapType(IntegerType(), IntegerType(), False), False),
         ]
     )
 

--- a/tests/test_enum_types.py
+++ b/tests/test_enum_types.py
@@ -1,0 +1,31 @@
+from enum import Enum, IntEnum
+
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from sparkdantic.model import SparkModel
+
+
+class IntTestEnum(IntEnum):
+    X = 1
+    Y = 2
+
+
+class StrTestEnum(str, Enum):
+    A = 'a'
+    B = 'b'
+
+
+class EnumValuesModel(SparkModel):
+    a: IntTestEnum
+    b: StrTestEnum
+
+
+def test_enum_values():
+    expected_schema = StructType(
+        [
+            StructField('a', IntegerType(), False),
+            StructField('b', StringType(), False),
+        ]
+    )
+    generated_schema = EnumValuesModel.model_spark_schema()
+    assert generated_schema == expected_schema

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 import pytest
 
 from sparkdantic.model import SparkModel
@@ -15,6 +17,14 @@ class BadType(SparkModel):
     t: NewType
 
 
+class BadEnum(Enum):
+    this = 'bad'
+
+
+class BadEnumType(SparkModel):
+    e: BadEnum
+
+
 def test_value_error():
     with pytest.raises(TypeError):
         BadListType(values=[1, 2]).model_spark_schema()
@@ -23,3 +33,12 @@ def test_value_error():
 def test_bad_type():
     with pytest.raises(TypeError):
         BadType(t=NewType()).model_spark_schema()
+
+
+def test_bad_enum_type():
+    with pytest.raises(TypeError) as exc_info:
+        BadEnumType(e=BadEnum.this.value).model_spark_schema()
+
+    assert f'Enum {BadEnum} is not supported. Only int and str mixins are supported.' in str(
+        exc_info.value
+    )

--- a/tests/test_list_types.py
+++ b/tests/test_list_types.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from enum import IntEnum
 from typing import List, Optional
 
 from pyspark.sql.types import (
@@ -20,6 +21,11 @@ from pyspark.sql.types import (
 from sparkdantic.model import SparkModel
 
 
+class IntTestEnum(IntEnum):
+    X = 1
+    Y = 2
+
+
 class MyModel(SparkModel):
     k: str
 
@@ -36,6 +42,7 @@ class ListValuesModel(SparkModel):
     ii: List[timedelta]
     oo: List[MyModel]
     o1: Optional[List[MyModel]]
+    o2: Optional[List[IntTestEnum]]
 
 
 def test_list_values():
@@ -56,6 +63,7 @@ def test_list_values():
             StructField(
                 'o1', ArrayType(StructType([StructField('k', StringType(), False)]), True), True
             ),
+            StructField('o2', ArrayType(IntegerType(), True), True),
         ]
     )
     generated_schema = ListValuesModel.model_spark_schema()

--- a/tests/test_optional_types.py
+++ b/tests/test_optional_types.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from enum import IntEnum
 from typing import Optional
 
 from pyspark.sql.types import (
@@ -19,6 +20,11 @@ from pyspark.sql.types import (
 from sparkdantic.model import SparkModel
 
 
+class IntTestEnum(IntEnum):
+    X = 1
+    Y = 2
+
+
 class OptionalValuesModel(SparkModel):
     g: Optional[int]
     h: Optional[float]
@@ -29,6 +35,7 @@ class OptionalValuesModel(SparkModel):
     z: Optional[date]
     dd: Optional[datetime]
     hh: Optional[timedelta]
+    ii: Optional[IntTestEnum]
 
 
 def test_optional_values():
@@ -43,6 +50,7 @@ def test_optional_values():
             StructField('z', DateType(), True),
             StructField('dd', TimestampType(), True),
             StructField('hh', DayTimeIntervalType(0, 3), True),
+            StructField('ii', IntegerType(), True),
         ]
     )
     generated_schema = OptionalValuesModel.model_spark_schema()


### PR DESCRIPTION
👋 @mitchelllisle (hope there's room for another Mitch here 😂)

## Changes
- Added support for Enum mixed with `int` or `str`
  - Default behaviour for data generation is to generate data for all `Enum` values
- Updated docstrings and documentation, `black` reformatting stuff
- Minor refactor of existing code (mainly `SparkModel` methods)

## To do
Once the proposal is accepted and all comments are resolved:
- [x] Bump minor version
- [x] Add enum docs to `README.md`