### PR TITLE
Optional objects in array

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/mitchelllisle/sparkdantic/graph/badge.svg?token=O6PPQX4FEX)](https://codecov.io/gh/mitchelllisle/sparkdantic)
 [![PyPI version](https://badge.fury.io/py/sparkdantic.svg)](https://badge.fury.io/py/sparkdantic)
 
-> 1️⃣ version: 0.20.3
+> 1️⃣ version: 0.20.4
 
 > ✍️ author: Mitchell Lisle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sparkdantic"
-version = "0.20.3"
+version = "0.20.4"
 description = "A pydantic -> spark schema library"
 authors = ["Mitchell Lisle <m.lisle90@gmail.com>"]
 readme = "README.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.3
+current_version = 0.20.4
 commit = True
 tag = False
 

--- a/src/sparkdantic/__init__.py
+++ b/src/sparkdantic/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.20.3'
+__version__ = '0.20.4'
 __author__ = 'Mitchell Lisle'
 __email__ = 'm.lisle90@gmail.com'
 

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -349,7 +349,7 @@ class SparkModel(BaseModel):
                 array_type = inner_type.model_spark_schema()
                 inner_nullable = nullable
             else:
-                # Check if it's an accepted Enum
+                # Check if it's an accepted Enum or optional SparkModel subclass
                 array_type, inner_nullable = cls._type_to_spark(inner_type, [])
             return ArrayType(array_type, inner_nullable), nullable
         elif origin is dict:
@@ -369,6 +369,8 @@ class SparkModel(BaseModel):
         elif origin is Annotated:
             # first arg of annotated type is the type, second is metadata that we don't do anything with (yet)
             t = args[0]
+        elif issubclass(t, SparkModel):
+            return t.model_spark_schema(), nullable
 
         if issubclass(t, Enum):
             t = cls._get_enum_mixin_type(t)

--- a/tests/test_list_types.py
+++ b/tests/test_list_types.py
@@ -44,6 +44,7 @@ class ListValuesModel(SparkModel):
     o1: Optional[List[MyModel]]
     o2: Optional[List[IntTestEnum]]
     o3: list[str]
+    o4: List[Optional[MyModel]]
     j: list[Union[str, None]]
 
 
@@ -67,6 +68,9 @@ def test_list_values():
             ),
             StructField('o2', ArrayType(IntegerType(), False), True),
             StructField('o3', ArrayType(StringType(), False), False),
+            StructField(
+                'o4', ArrayType(StructType([StructField('k', StringType(), False)]), True), False
+            ),
             StructField('j', ArrayType(StringType(), True), False),
         ]
     )


### PR DESCRIPTION
Generating the spark schema for classes with **optional** **objects** in lists used to result in errors.

This happened because the `inner_type` was of type `<class 'typing._UnionGenericAlias'>` which is not a subclass of SparkModel (see [line](https://github.com/mitchelllisle/sparkdantic/pull/261/files#diff-d0724184b9d94a5ae82a0fe7de0cbd5e7968b40f413fff766b849be2b44d8f62R348))

`<class 'typing._UnionGenericAlias'>` is also not a traditional class so `inspect.isclass()` returns False as well

**How-to-replicate:**

```python
from sparkdantic import SparkModel
from typing import Optional, List

class InnerModel(SparkModel):
    some_field: str

class SomeClass(SparkModel):
    models: List[Optional[InnerModel]]

SomeClass.model_spark_schema()
> TypeError: Type <class 'InnerModel'> not recognized
```

This MR fixes that using a recursive approach.