### PR TITLE
Use Field alias when generating data

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/mitchelllisle/sparkdantic/graph/badge.svg?token=O6PPQX4FEX)](https://codecov.io/gh/mitchelllisle/sparkdantic)
 [![PyPI version](https://badge.fury.io/py/sparkdantic.svg)](https://badge.fury.io/py/sparkdantic)
 
-> 1️⃣ version: 0.20.4
+> 1️⃣ version: 0.20.5
 
 > ✍️ author: Mitchell Lisle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sparkdantic"
-version = "0.20.4"
+version = "0.20.5"
 description = "A pydantic -> spark schema library"
 authors = ["Mitchell Lisle <m.lisle90@gmail.com>"]
 readme = "README.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.4
+current_version = 0.20.5
 commit = True
 tag = False
 

--- a/src/sparkdantic/__init__.py
+++ b/src/sparkdantic/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.20.4'
+__version__ = '0.20.5'
 __author__ = 'Mitchell Lisle'
 __email__ = 'm.lisle90@gmail.com'
 

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -211,6 +211,7 @@ class SparkModel(BaseModel):
         specs = {} if not specs else specs
         generator = dg.DataGenerator(spark, seedColumnName='_seed_id', rows=n_rows, **kwargs)
         for name, field in cls.model_fields.items():
+            name = getattr(field, 'alias') or name
             spec = specs.get(name)
 
             if (

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -211,8 +211,8 @@ class SparkModel(BaseModel):
         specs = {} if not specs else specs
         generator = dg.DataGenerator(spark, seedColumnName='_seed_id', rows=n_rows, **kwargs)
         for name, field in cls.model_fields.items():
-            name = getattr(field, 'alias') or name
             spec = specs.get(name)
+            name = getattr(field, 'alias') or name
 
             if (
                 spec is None

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -2,7 +2,6 @@ from enum import Enum, IntEnum
 from typing import Dict, List, Optional, Union, get_args, get_origin
 
 import dbldatagen as dg
-import pyspark.sql
 import pytest
 from faker import Faker
 from pydantic import Field
@@ -126,6 +125,6 @@ def test_missing_mapping_source(spark: SparkSession):
 
 
 def test_use_field_alias(spark: SparkSession):
-    data_gen: pyspark.sql.DataFrame = AliasModel.generate_data(spark, n_rows=1)
+    data_gen = AliasModel.generate_data(spark, n_rows=1)
 
     assert data_gen.columns == ['_val']


### PR DESCRIPTION
Hi again!

Here's a simple fix for an issue with data generation

The case presented below is where the model prioritizes the field name vs. the alias. This led to inconsistency issues since the generated spark model would prioritize the alias.

I also thought that when setting the `ColumnGenerationSpec` it would be more intuitive to use the field name instead of the alias, hence why I explicitly correct the name after getting the spec.


```python
class AliasModel(SparkModel):
    val: int = Field(alias='_val')

gen_df = AliasModel.generate_data(spark)

assert '_val' in gen_df.columns
> AssertionError
````