### PR TITLE
Add support for custom types.

### DIFF
--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -303,8 +303,10 @@ class SparkModel(BaseModel):
         """
         spark_type = type_map.get(t)
         if spark_type is None:
-            raise TypeError(f'Type {t} not recognized')
-
+            parent_type = t.__base__
+            spark_type = type_map.get(parent_type)
+            if spark_type is None:
+                raise TypeError(f'Type {t} not recognized')
         spark_type.nullable = nullable
         return spark_type
 

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -307,6 +307,7 @@ class SparkModel(BaseModel):
             spark_type = type_map.get(parent_type)
             if spark_type is None:
                 raise TypeError(f'Type {t} not recognized')
+
         spark_type.nullable = nullable
         return spark_type
 


### PR DESCRIPTION
If the type is not found in the type map, will check the parent type. 

Note that this only accounts for one level of inheritance, which is typical for custom Pydantic types.