### PR TITLE
Support BaseModel inside complex type

### DIFF
--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -162,11 +162,11 @@ class SparkModel(BaseModel):
         return cls._post_mapping_process(generated)
 
 
-def create_spark_schema(model: Type[BaseModel]) -> StructType:
+def create_spark_schema(model: Type) -> StructType:
     """Generates a PySpark schema from the model fields.
 
     Args:
-        model (Type[BaseModel]): The pydantic model to generate the schema from.
+        model (Type): The pydantic model to generate the schema from.
 
     Returns:
         StructType: The generated PySpark schema.
@@ -315,7 +315,7 @@ def _type_to_spark(t: Type, metadata) -> Tuple[DataType, bool]:
     if origin is list:
         inner_type = args[0]
         if _is_supported_subclass(inner_type):
-            array_type = inner_type.model_spark_schema()
+            array_type = create_spark_schema(inner_type)
             inner_nullable = nullable
         else:
             # Check if it's an accepted Enum or optional SparkModel subclass
@@ -338,8 +338,8 @@ def _type_to_spark(t: Type, metadata) -> Tuple[DataType, bool]:
     elif origin is Annotated:
         # first arg of annotated type is the type, second is metadata that we don't do anything with (yet)
         t = args[0]
-    elif issubclass(t, SparkModel):
-        return t.model_spark_schema(), nullable
+    elif _is_supported_subclass(t):
+        return create_spark_schema(t), nullable
 
     if issubclass(t, Enum):
         t = _get_enum_mixin_type(t)

--- a/tests/test_dict_types.py
+++ b/tests/test_dict_types.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from enum import IntEnum
 from typing import Dict, Union
 
+from pydantic import BaseModel
 from pyspark.sql.types import (
     BinaryType,
     BooleanType,
@@ -26,6 +27,10 @@ class IntTestEnum(IntEnum):
     Y = 2
 
 
+class TestBase(BaseModel):
+    name: str
+
+
 class DictValuesModel(SparkModel):
     s: Dict[int, int]
     t: Dict[float, float]
@@ -39,6 +44,7 @@ class DictValuesModel(SparkModel):
     kk: Dict[IntTestEnum, IntTestEnum]
     ll: dict[str, str]
     mm: dict[str, Union[str, None]]
+    nn: dict[str, TestBase]
 
 
 def test_dict_values():
@@ -58,6 +64,13 @@ def test_dict_values():
             StructField('kk', MapType(IntegerType(), IntegerType(), False), False),
             StructField('ll', MapType(StringType(), StringType(), False), False),
             StructField('mm', MapType(StringType(), StringType(), True), False),
+            StructField(
+                'nn',
+                MapType(
+                    StringType(), StructType([StructField('name', StringType(), False)]), False
+                ),
+                False,
+            ),
         ]
     )
 

--- a/tests/test_list_types.py
+++ b/tests/test_list_types.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from enum import IntEnum
 from typing import List, Optional, Union
 
+from pydantic import BaseModel
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -30,6 +31,10 @@ class MyModel(SparkModel):
     k: str
 
 
+class MyBaseModel(BaseModel):
+    k: str
+
+
 class ListValuesModel(SparkModel):
     m: List[int]
     n: List[float]
@@ -42,9 +47,11 @@ class ListValuesModel(SparkModel):
     ii: List[timedelta]
     oo: List[MyModel]
     o1: Optional[List[MyModel]]
+    ob1: Optional[List[MyBaseModel]]
     o2: Optional[List[IntTestEnum]]
     o3: list[str]
     o4: List[Optional[MyModel]]
+    ob4: List[Optional[MyBaseModel]]
     j: list[Union[str, None]]
 
 
@@ -66,10 +73,16 @@ def test_list_values():
             StructField(
                 'o1', ArrayType(StructType([StructField('k', StringType(), False)]), True), True
             ),
+            StructField(
+                'ob1', ArrayType(StructType([StructField('k', StringType(), False)]), True), True
+            ),
             StructField('o2', ArrayType(IntegerType(), False), True),
             StructField('o3', ArrayType(StringType(), False), False),
             StructField(
                 'o4', ArrayType(StructType([StructField('k', StringType(), False)]), True), False
+            ),
+            StructField(
+                'ob4', ArrayType(StructType([StructField('k', StringType(), False)]), True), False
             ),
             StructField('j', ArrayType(StringType(), True), False),
         ]


### PR DESCRIPTION
- Array type can be a SparkModel or BaseModel
- Any complex type that contain BaseModel supported
- Add tests for dict and array type with BaseModel type
