### PR TITLE
Fix override nullability

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ StructType([
     StructField('hobbies', ArrayType(StringType(), False), False)
 ])
 ```
+> ℹ️  In addition to the automatic type conversion, you can also explicitly coerce data types to Spark native types by 
+>  setting the `spark_type` attribute in the `Field` function from Pydantic, like so: `Field(spark_type=DataType)`.
+>  Please replace DataType with the actual Spark data type you want to use.
+>  This is useful when you want to use a specific data type then the one that Sparkdantic infers by default. 
+
 
 ### Generating fake data
 Once you've defined a schema you can generate some fake data for your class. Useful for testing purposes as well as for

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -196,7 +196,7 @@ def create_spark_schema(model: Type) -> StructType:
 
 
 def _get_native_spark_type(t: Type[DataType], meta: BaseMetadata) -> DataType:
-    """Returns the native PySpark data type for a given Python type.
+    """Returns the instantiated type for a given PySpark type.
 
     Args:
         t (Type[DataType]): The PySpark data type.

--- a/tests/test_type_override.py
+++ b/tests/test_type_override.py
@@ -1,6 +1,6 @@
 import pytest
 from pydantic import UUID4, Field
-from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+from pyspark.sql.types import IntegerType, LongType, StringType, StructField, StructType
 
 from sparkdantic import SparkModel
 
@@ -8,12 +8,17 @@ from sparkdantic import SparkModel
 class MyModel(SparkModel):
     id: UUID4 = Field(spark_type=StringType)
     t: str = Field(spark_type=IntegerType)
+    o: int | None = Field(spark_type=LongType)
 
 
 def test_override():
     schema = MyModel.model_spark_schema()
     expected = StructType(
-        [StructField('id', StringType(), False), StructField('t', IntegerType(), False)]
+        [
+            StructField('id', StringType(), False),
+            StructField('t', IntegerType(), False),
+            StructField('o', LongType(), True),
+        ]
     )
     assert schema == expected
 


### PR DESCRIPTION
Avoids using _type_to_spark for native spark types in the create_spark_schema function, so that nullabilty info is not lost.
- Adds function for handling native spark types
- Adds function for setting Decimal's scale and precision
- Describe override option in README.md
