### PR TITLE
Improve model alias support

### DIFF
--- a/COVERAGE.txt
+++ b/COVERAGE.txt
@@ -2,6 +2,6 @@ Name                            Stmts   Miss  Cover
 ---------------------------------------------------
 src/sparkdantic/__init__.py         5      0   100%
 src/sparkdantic/generation.py      36      0   100%
-src/sparkdantic/model.py          157      2    99%
+src/sparkdantic/model.py          174      2    99%
 ---------------------------------------------------
-TOTAL                             198      2    99%
+TOTAL                             215      2    99%

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -96,10 +96,7 @@ class SparkModel(BaseModel):
 
     Methods:
         model_spark_schema: Generates a PySpark schema from the model fields.
-        _is_nullable: Determines if a type is nullable and returns the type without the Union.
-        _get_spark_type: Returns the corresponding PySpark data type for a given Python type, considering nullability.
-        _get_enum_mixin_type: Returns the mixin type of Enum.
-        _type_to_spark: Converts a given Python type to a corresponding PySpark data type.
+        generate_data: Generates PySpark DataFrame based on the schema and the column specs.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, use_enum_values=True)

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -138,6 +138,7 @@ class SparkModel(BaseModel):
         spark: SparkSession,
         n_rows: int = 100,
         specs: Optional[ColumnSpecs] = None,
+        by_alias: bool = True,
         **kwargs,
     ) -> DataFrame:
         """Generates PySpark DataFrame based on the schema and the column specs.
@@ -146,6 +147,7 @@ class SparkModel(BaseModel):
             spark (SparkSession): The Spark session.
             n_rows (int, optional): Number of rows. Defaults to 100.
             specs (Optional[ColumnSpecs]): Column specifications. Defaults to None.
+            by_alias (bool): Indicates whether to use attribute aliases (`serialization_alias` or `alias`) or not.
 
         Returns:
             DataFrame: The generated PySpark DataFrame.
@@ -154,7 +156,9 @@ class SparkModel(BaseModel):
         generator = dg.DataGenerator(spark, seedColumnName='_seed_id', rows=n_rows, **kwargs)
         for name, field in cls.model_fields.items():
             spec = specs.get(name)
-            name = getattr(field, 'alias') or name
+            if by_alias:
+                # When both serialzation_alias and alias are used, serialization_alias takes precedence
+                name = getattr(field, 'serialization_alias') or getattr(field, 'alias') or name
 
             if (
                 spec is None

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -20,7 +20,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
-from sparkdantic.model import SparkModel
+from sparkdantic.model import SparkModel, create_spark_schema
 
 
 class DecimalModel(SparkModel):
@@ -178,3 +178,26 @@ def test_field_aliases():
             StructField('f', StructType([StructField('z', IntegerType(), False)]), False)
         ]
     )
+
+
+def test_spark_schema_is_created_for_basemodel():
+    class MyModel(BaseModel):
+        a: int
+
+    schema = create_spark_schema(MyModel)
+
+    assert schema == StructType(
+        [
+            StructField('a', IntegerType(), False),
+        ]
+    )
+
+
+def test_create_spark_schema_raises_error_for_invalid_type():
+    class NotAModel:
+        a: int
+
+    with pytest.raises(TypeError) as exc_info:
+        create_spark_schema(NotAModel)
+
+    assert f'`model` must be of type `SparkModel` or `pydantic.BaseModel`' in str(exc_info.value)

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal, Optional
 from uuid import UUID
 
 import pytest
-from pydantic import BaseModel, Field, SecretBytes, SecretStr
+from pydantic import AliasChoices, AliasPath, BaseModel, Field, SecretBytes, SecretStr
 from pyspark.sql.types import (
     BinaryType,
     BooleanType,
@@ -44,6 +44,23 @@ class RawValuesModel(SparkModel):
     jj: SecretStr
     x: str = Field(alias='_x')
     uuid: UUID
+
+
+class NestedAliasModel(SparkModel):
+    z: int = Field(alias='_z')
+
+
+class AliasModel(SparkModel):
+    a: int = Field(alias='_a')
+    b: int = Field(serialization_alias='_b')
+    c: int = Field(validation_alias='_c')
+    d: int
+    _e: int  # Omitted from the model schema
+    f: NestedAliasModel = Field(alias='_f')
+    g: int = Field(alias='_g', serialization_alias='__g')
+    h: int = Field(alias='_h', serialization_alias='h_s', validation_alias='h_v')
+    i: int = Field(validation_alias=AliasChoices('i_first', 'i_second'))
+    j: int = Field(validation_alias=AliasPath('j_array', 0))
 
 
 def test_raw_values():
@@ -145,41 +162,6 @@ def test_safe_casting():
     )
 
 
-def test_field_aliases():
-    class SubModel(SparkModel):
-        z: int = Field(alias='_z')
-    
-    class ModelWithAliases(SparkModel):
-        a: int = Field(alias='_a')
-        b: int = Field(serialization_alias='_b')
-        c: int = Field(alias='_c', serialization_alias='__c')
-        d: int
-        _e: int  # Omitted from the model schema
-        f: SubModel = Field(alias='_f')
-
-    aliased_schema = ModelWithAliases.model_spark_schema()
-    assert aliased_schema == StructType(
-        [
-            StructField('_a', IntegerType(), False),
-            StructField('_b', IntegerType(), False),
-            StructField('__c', IntegerType(), False),
-            StructField('d', IntegerType(), False),
-            StructField('_f', StructType([StructField('_z', IntegerType(), False)]), False)
-        ]
-    )
-
-    schema = ModelWithAliases.model_spark_schema(by_alias=False)
-    assert schema == StructType(
-        [
-            StructField('a', IntegerType(), False),
-            StructField('b', IntegerType(), False),
-            StructField('c', IntegerType(), False),
-            StructField('d', IntegerType(), False),
-            StructField('f', StructType([StructField('z', IntegerType(), False)]), False)
-        ]
-    )
-
-
 def test_spark_schema_is_created_for_basemodel():
     class MyModel(BaseModel):
         a: int
@@ -201,3 +183,87 @@ def test_create_spark_schema_raises_error_for_invalid_type():
         create_spark_schema(NotAModel)
 
     assert f'`model` must be of type `SparkModel` or `pydantic.BaseModel`' in str(exc_info.value)
+
+
+def test_spark_schema_contains_validation_field_aliases_by_default():
+    schema = AliasModel.model_spark_schema()
+    assert schema == StructType(
+        [
+            StructField('_a', IntegerType(), False),
+            StructField('b', IntegerType(), False),
+            StructField('_c', IntegerType(), False),
+            StructField('d', IntegerType(), False),
+            StructField('_f', StructType([StructField('_z', IntegerType(), False)]), False),
+            StructField('_g', IntegerType(), False),
+            StructField('h_v', IntegerType(), False),
+            StructField('i_first', IntegerType(), False),
+            StructField('j', IntegerType(), False),
+        ]
+    )
+
+
+def test_spark_schema_contains_field_names_when_not_using_aliases():
+    schema = AliasModel.model_spark_schema(by_alias=False)
+    assert schema == StructType(
+        [
+            StructField('a', IntegerType(), False),
+            StructField('b', IntegerType(), False),
+            StructField('c', IntegerType(), False),
+            StructField('d', IntegerType(), False),
+            StructField('f', StructType([StructField('z', IntegerType(), False)]), False),
+            StructField('g', IntegerType(), False),
+            StructField('h', IntegerType(), False),
+            StructField('i', IntegerType(), False),
+            StructField('j', IntegerType(), False),
+        ]
+    )
+
+
+def test_spark_schema_contains_serialization_aliases_when_using_serialization_mode():
+    schema = AliasModel.model_spark_schema(mode='serialization')
+    assert schema == StructType(
+        [
+            StructField('_a', IntegerType(), False),
+            StructField('_b', IntegerType(), False),
+            StructField('c', IntegerType(), False),
+            StructField('d', IntegerType(), False),
+            StructField('_f', StructType([StructField('_z', IntegerType(), False)]), False),
+            StructField('__g', IntegerType(), False),
+            StructField('h_s', IntegerType(), False),
+            StructField('i', IntegerType(), False),
+            StructField('j', IntegerType(), False),
+        ]
+    )
+
+
+def test_spark_schema_contains_field_names_when_using_serialization_mode_and_not_using_aliases():
+    schema = AliasModel.model_spark_schema(by_alias=False, mode='serialization')
+    assert schema == StructType(
+        [
+            StructField('a', IntegerType(), False),
+            StructField('b', IntegerType(), False),
+            StructField('c', IntegerType(), False),
+            StructField('d', IntegerType(), False),
+            StructField('f', StructType([StructField('z', IntegerType(), False)]), False),
+            StructField('g', IntegerType(), False),
+            StructField('h', IntegerType(), False),
+            StructField('i', IntegerType(), False),
+            StructField('j', IntegerType(), False),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    'by_alias, mode',
+    [
+        (True, 'validation'),
+        (False, 'validation'),
+        (True, 'serialization'),
+        (False, 'serialization'),
+    ],
+)
+def test_spark_model_schema_json_has_same_field_names_to_model_json_schema(by_alias, mode):
+    spark_schema = AliasModel.model_spark_schema(by_alias=by_alias, mode=mode)
+    json_schema = AliasModel.model_json_schema(by_alias=by_alias, mode=mode)
+
+    assert sorted(spark_schema.fieldNames()) == sorted(json_schema['properties'].keys())

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -34,7 +34,7 @@ class SampleModel(SparkModel):
 
 class AliasModel(SparkModel):
     val: int = Field(alias='_val')
-    s_val: str = Field(serialization_alias='serialized_val')
+    s_val: str = Field(serialization_alias='serialized_val', validation_alias='validation_val')
 
 
 def test_generate_data(spark: SparkSession):
@@ -129,4 +129,4 @@ def test_missing_mapping_source(spark: SparkSession):
 def test_use_field_alias(spark: SparkSession):
     data_gen = AliasModel.generate_data(spark, n_rows=1, by_alias=True)
 
-    assert sorted(data_gen.columns) == sorted(['_val', 'serialized_val'])
+    assert sorted(data_gen.columns) == sorted(['_val', 'validation_val'])

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -34,6 +34,7 @@ class SampleModel(SparkModel):
 
 class AliasModel(SparkModel):
     val: int = Field(alias='_val')
+    s_val: str = Field(serialization_alias='serialized_val')
 
 
 def test_generate_data(spark: SparkSession):
@@ -126,6 +127,6 @@ def test_missing_mapping_source(spark: SparkSession):
 
 
 def test_use_field_alias(spark: SparkSession):
-    data_gen = AliasModel.generate_data(spark, n_rows=1)
+    data_gen = AliasModel.generate_data(spark, n_rows=1, by_alias=True)
 
-    assert data_gen.columns == ['_val']
+    assert sorted(data_gen.columns) == sorted(['_val', 'serialized_val'])


### PR DESCRIPTION
## Changes
- Adds support for `validation_alias` and `serialization_alias` for `pydantic.Field` (see [Alias docs](https://docs.pydantic.dev/2.7/concepts/alias/#aliaspath-and-aliaschoices))
  - The behaviour added to `SparkModel.model_spark_schema()` is the same as that of `pydantic.BaseModel.model_json_schema()` (see [docs](https://docs.pydantic.dev/2.7/api/base_model/#pydantic.BaseModel.model_json_schema))
  - `'validation'` is the default mode by which to generate the schema (`'serialization'` is also supported)
  - `by_alias` is `True` by default
- Improves type annotations and variable names
- Clean up docstrings

## Notes
- Tests could potentially be cleaned up and parameterised a bit better, but I opted for descriptive test function names instead. Happy to update these