### PR TITLE
Support StructType override

### DIFF
--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -166,6 +166,8 @@ def create_json_spark_schema(
                     spark_type = override
                 elif utils.have_pyspark and _is_spark_datatype(override):
                     spark_type = override.typeName()
+                    if spark_type == 'struct':
+                        spark_type = override.jsonValue()
                 else:
                     msg = '`spark_type` override should be a `str` type name (e.g. long)'
                     if utils.have_pyspark:
@@ -409,4 +411,6 @@ def _is_spark_datatype(t: Type) -> bool:
     Returns:
         bool: a boolean indicating if the type is a PySpark DataType.
     """
+    if isinstance(t, StructType):
+        return True
     return inspect.isclass(t) and issubclass(t, DataType)

--- a/tests/test_type_override.py
+++ b/tests/test_type_override.py
@@ -13,12 +13,14 @@ def test_override():
         id: int = Field(spark_type=StringType)
         t: str = Field(spark_type=IntegerType)
         o: Union[int, None] = Field(spark_type=LongType)
+        s: dict = Field(spark_type=StructType([StructField('a', StringType(), False)]))
 
     expected_schema = StructType(
         [
             StructField('id', StringType(), False),
             StructField('t', IntegerType(), False),
             StructField('o', LongType(), True),
+            StructField('s', StructType([StructField('a', StringType(), False)]), False),
         ]
     )
     actual_schema = MyModel.model_spark_schema()


### PR DESCRIPTION
hey @mitchelllisle, Would be nice if overriding with StructType can be supported.  This is needed for cases where type is dict and MapType or using BaseModel not desired. Thoughts?