### PR TITLE
Use `Field`/`SparkField`'s `description` attribute to populate column comments

### DIFF
--- a/COVERAGE.txt
+++ b/COVERAGE.txt
@@ -1,8 +1,8 @@
 Name                            Stmts   Miss  Cover
 ---------------------------------------------------
-src/sparkdantic/__init__.py         4      0   100%
+src/sparkdantic/__init__.py         5      0   100%
 src/sparkdantic/exceptions.py       2      0   100%
-src/sparkdantic/model.py          144      3    98%
+src/sparkdantic/model.py          167      4    98%
 src/sparkdantic/utils.py           19      3    84%
 ---------------------------------------------------
-TOTAL                             169      6    96%
+TOTAL                             193      7    96%

--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -161,6 +161,9 @@ def create_json_spark_schema(
         annotation_or_return_type = _get_annotation_or_return_type(info)
         field_type = _get_union_type_arg(annotation_or_return_type)
 
+        description = getattr(info, 'description', None)
+        comment = {'comment': description} if description else {}
+
         spark_type: Union[str, Dict[str, Any]]
 
         try:
@@ -196,7 +199,7 @@ def create_json_spark_schema(
             'name': name,
             'type': spark_type,
             'nullable': nullable,
-            'metadata': {},
+            'metadata': comment,
         }
         fields.append(struct_field)
     return {

--- a/tests/test_field_descriptions.py
+++ b/tests/test_field_descriptions.py
@@ -1,0 +1,53 @@
+from pyspark.sql.types import StringType, StructField, StructType
+
+from sparkdantic import SparkField, SparkModel
+
+
+class DescriptionModel(SparkModel):
+    field_with_description: str = SparkField(description='This is a test description.')
+    field_without_description: str = SparkField()
+
+
+def test_spark_schema_contains_field_descriptions():
+    expected_schema = StructType(
+        [
+            StructField(
+                'field_with_description',
+                StringType(),
+                False,
+                metadata={'comment': 'This is a test description.'},
+            ),
+            StructField(
+                'field_without_description',
+                StringType(),
+                False,
+                metadata={},
+            ),
+        ]
+    )
+
+    actual_schema = DescriptionModel.model_spark_schema()
+    assert actual_schema == expected_schema
+
+
+def test_spark_schema_json_contains_field_descriptions():
+    expected_json_schema = {
+        'type': 'struct',
+        'fields': [
+            {
+                'name': 'field_with_description',
+                'type': 'string',
+                'nullable': False,
+                'metadata': {'comment': 'This is a test description.'},
+            },
+            {
+                'name': 'field_without_description',
+                'type': 'string',
+                'nullable': False,
+                'metadata': {},
+            },
+        ],
+    }
+
+    actual_json_schema = DescriptionModel.model_json_spark_schema()
+    assert actual_json_schema == expected_json_schema


### PR DESCRIPTION
Populates the `metadata` key in the resulting schema with `{"comment": description}`, where `description` is provided via the related `Field` or `SparkField`.