### PR TITLE
feat: optionally exclude fields based on pydantic's Field.exclude attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ class MyEnumModel(SparkModel):
     switch: Switch
 ```
 
+> ℹ️ A field can be excluded from the Spark schema using the pydantic's `exclude` Field attribute. This is
+> useful when e.g. the pydantic model has Spark incompatible fields. Note that `exclude` is a pydantic field 
+> attribute and not a sparkdantic feature. Setting it will exclude the field from any pydantic serialisation/deserialisation.
+
+```python
+from pydantic import Field
+from sparkdantic import SparkModel
+from typing import Any
+
+class MyModel(SparkModel):
+    name: str
+    age: int
+    arbitrary_data: Any = Field(exclude=True)
+
+```
+Running `MyModel.model_spark_schema(exclude_fields=True)` should return the following schema:
+
+```python
+StructType([
+    StructField('name', StringType(), False),
+    StructField('age', IntegerType(), False)
+])
+```
+
+Calling `model_spark_schema` without the option raises exception due to incompatible types.
 ### Generating a PySpark Schema
 
 #### Using `SparkModel`

--- a/poetry.lock
+++ b/poetry.lock
@@ -612,14 +612,14 @@ colorama = ">=0.4"
 
 [[package]]
 name = "hypothesis"
-version = "6.131.14"
+version = "6.131.15"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.9"
 groups = ["test"]
 files = [
-    {file = "hypothesis-6.131.14-py3-none-any.whl", hash = "sha256:4cb939361a75c5946fe3e049d69737b00bde3908f162da6dcea5b2a326cea0a2"},
-    {file = "hypothesis-6.131.14.tar.gz", hash = "sha256:347edc46cfe9bfcfb0598c4c927ed8fd573edfc8bacd2162023c4cf16accb702"},
+    {file = "hypothesis-6.131.15-py3-none-any.whl", hash = "sha256:e02e67e9f3cfd4cd4a67ccc03bf7431beccc1a084c5e90029799ddd36ce006d7"},
+    {file = "hypothesis-6.131.15.tar.gz", hash = "sha256:11849998ae5eecc8c586c6c98e47677fcc02d97475065f62768cfffbcc15ef7a"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1296,14 +1296,14 @@ files = [
 
 [[package]]
 name = "pep8-naming"
-version = "0.15.0"
+version = "0.15.1"
 description = "Check PEP-8 naming conventions, plugin for flake8"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pep8_naming-0.15.0-py3-none-any.whl", hash = "sha256:2ce36937ff0421d871a634f4a0c2af06f994fe22c9055ea9813ca72d562754da"},
-    {file = "pep8_naming-0.15.0.tar.gz", hash = "sha256:a637ee5144f7585c800b1fc6eeb996fa35a2ef0f2690880a9e1b29cb9f6e8359"},
+    {file = "pep8_naming-0.15.1-py3-none-any.whl", hash = "sha256:eb63925e7fd9e028c7f7ee7b1e413ec03d1ee5de0e627012102ee0222c273c86"},
+    {file = "pep8_naming-0.15.1.tar.gz", hash = "sha256:f6f4a499aba2deeda93c1f26ccc02f3da32b035c8b2db9696b730ef2c9639d29"},
 ]
 
 [package.dependencies]

--- a/tests/test_exclude_field.py
+++ b/tests/test_exclude_field.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+import pytest
+from pydantic import Field
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from sparkdantic.exceptions import TypeConversionError
+from sparkdantic.model import SparkModel
+
+
+def test_exclude():
+    class ModelWithIncompatibleTypes(SparkModel):
+        a: int
+        b: Any = Field(exclude=True)
+        c: str
+        d: float = Field(exclude=True)
+
+    expected_schema = StructType(
+        [
+            StructField('a', IntegerType(), False),
+            StructField('c', StringType(), False),
+        ]
+    )
+    generated_schema = ModelWithIncompatibleTypes.model_spark_schema(exclude_fields=True)
+    assert generated_schema == expected_schema
+    # Default is to include all fields, so should raise TypeConversionError
+    with pytest.raises(TypeConversionError):
+        ModelWithIncompatibleTypes.model_spark_schema()
+    with pytest.raises(TypeConversionError):
+        ModelWithIncompatibleTypes.model_spark_schema(exclude_fields=False)
+
+
+def test_nested_exclude():
+    class ModelWithIncompatibleTypes(SparkModel):
+        a: int
+        b: Any = Field(exclude=True)
+        c: str
+        d: float = Field(exclude=True)
+
+    class ModelWithIncompatibleNestedTypes(SparkModel):
+        a: ModelWithIncompatibleTypes
+
+    expected_schema = StructType(
+        [
+            StructField(
+                'a',
+                StructType(
+                    [
+                        StructField('a', IntegerType(), False),
+                        StructField('c', StringType(), False),
+                    ]
+                ),
+                nullable=False,
+            )
+        ]
+    )
+    generated_schema = ModelWithIncompatibleNestedTypes.model_spark_schema(exclude_fields=True)
+    assert generated_schema == expected_schema
+    # Default is to include all fields, so should raise TypeConversionError
+    with pytest.raises(TypeConversionError):
+        ModelWithIncompatibleNestedTypes.model_spark_schema()
+    with pytest.raises(TypeConversionError):
+        ModelWithIncompatibleNestedTypes.model_spark_schema(exclude_fields=False)


### PR DESCRIPTION
Use the pydantic Field attribute `exclude` to exclude fields from the Spark schema. Default is to keep them but providing `exclude_fields=True` to the main conversion APIs excludes them.

Closes #697 