### PR TITLE
Support DDL strings

### DIFF
--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -132,6 +132,29 @@ class SparkModel(BaseModel):
         """
         return create_json_spark_schema(cls, safe_casting, by_alias, mode, exclude_fields)
 
+    @classmethod
+    def model_ddl_spark_schema(
+        cls,
+        safe_casting: bool = False,
+        by_alias: bool = True,
+        mode: JsonSchemaMode = 'validation',
+        exclude_fields: bool = False,
+    ) -> str:
+        """Generates a Pyspark schema DDL String from the model fields.
+
+        Args:
+            model (pydantic.BaseModel or SparkModel): The pydantic model to generate the schema from.
+            safe_casting (bool): Indicates whether to use safe casting for integer types.
+            by_alias (bool): Indicates whether to use attribute aliases (`serialization_alias` or `alias`) or not.
+            mode (pydantic.json_schema.JsonSchemaMode): The mode in which to generate the schema.
+            exclude_fields (bool): Indicates whether to exclude fields from the schema. Fields to be excluded should
+              be annotated with `Field(exclude=True)` field attribute
+
+        Returns:
+            str: The generated DDL PySpark schema.
+        """
+        return create_ddl_spark_schema(cls, safe_casting, by_alias, mode, exclude_fields)
+
 
 def create_json_spark_schema(
     model: Type[BaseModelOrSparkModel],
@@ -221,6 +244,31 @@ def create_json_spark_schema(
         'type': 'struct',
         'fields': fields,
     }
+
+
+def create_ddl_spark_schema(
+    model: Type[BaseModelOrSparkModel],
+    safe_casting: bool = False,
+    by_alias: bool = True,
+    mode: JsonSchemaMode = 'validation',
+    exclude_fields: bool = False,
+) -> str:
+    """Generates a Pyspark schema DDL String from the model fields.
+
+    Args:
+        model (pydantic.BaseModel or SparkModel): The pydantic model to generate the schema from.
+        safe_casting (bool): Indicates whether to use safe casting for integer types.
+        by_alias (bool): Indicates whether to use attribute aliases (`serialization_alias` or `alias`) or not.
+        mode (pydantic.json_schema.JsonSchemaMode): The mode in which to generate the schema.
+        exclude_fields (bool): Indicates whether to exclude fields from the schema. Fields to be excluded should
+          be annotated with `Field(exclude=True)` field attribute
+
+    Returns:
+        str: The generated DDL PySpark schema.
+    """
+    utils.require_pyspark()
+    json_schema = create_json_spark_schema(model, safe_casting, by_alias, mode, exclude_fields)
+    return json_schema_to_ddl(json_schema)
 
 
 def create_spark_schema(
@@ -507,3 +555,59 @@ def _is_spark_datatype(t: Type) -> bool:
     if isinstance(t, StructType):
         return True
     return inspect.isclass(t) and issubclass(t, DataType)
+
+
+def json_schema_to_ddl(json_schema: Dict[str, Any]) -> str:
+    """Converts a JSON schema to a DDL string representation matching Spark's format.
+
+    Args:
+        json_schema (Dict[str, Any]): The JSON schema to convert.
+
+    Returns:
+        str: The DDL string representation of the schema.
+    """
+
+    def _json_type_to_ddl(json_type: Union[str, Dict[str, Any]]) -> str:
+        if isinstance(json_type, str):
+            # Map INTEGER to INT
+            if json_type.upper() == 'INTEGER':
+                return 'INT'
+            elif json_type.upper().startswith('DECIMAL'):
+                return json_type.upper().replace(' ', '')  # Remove whitespaces
+            else:
+                return json_type.upper()
+
+        if json_type['type'] == 'struct':
+            nested_fields = [
+                f"{field['name']}: {_json_type_to_ddl(field['type'])}"
+                for field in json_type['fields']
+            ]
+            return f"STRUCT<{', '.join(nested_fields)}>"
+
+        elif json_type['type'] == 'array':
+            element_type = _json_type_to_ddl(json_type['elementType'])
+            return f'ARRAY<{element_type}>'
+
+        elif json_type['type'] == 'map':
+            key_type = _json_type_to_ddl(json_type['keyType'])
+            value_type = _json_type_to_ddl(json_type['valueType'])
+            return f'MAP<{key_type}, {value_type}>'
+
+        elif json_type['type'] == 'decimal':
+            precision = json_type.get('precision', 10)
+            scale = json_type.get('scale', 0)
+            print(f'Precision: {precision}, Scale: {scale}')
+            return f'DECIMAL({precision},{scale})'
+
+        else:
+            # Map INTEGER to INT
+            return 'INT' if json_type['type'].upper() == 'INTEGER' else json_type['type'].upper()
+
+    field_ddls = []
+    for field in json_schema['fields']:
+        field_ddl = f"{field['name']} {_json_type_to_ddl(field['type'])}"
+        if not field['nullable']:
+            field_ddl += ' NOT NULL'
+        field_ddls.append(field_ddl)
+
+    return ','.join(field_ddls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from pyspark.sql import SparkSession
+
+
+@pytest.fixture(scope='session')
+def spark() -> SparkSession:
+    return SparkSession.builder.getOrCreate()

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -4,6 +4,7 @@ from typing import Annotated, Literal, Optional
 from uuid import UUID
 
 from pydantic import Field, SecretBytes, SecretStr
+from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     BinaryType,
     BooleanType,
@@ -21,7 +22,7 @@ from pyspark.sql.types import (
 from sparkdantic import SparkModel
 
 
-def test_base_type_fields():
+def test_base_type_fields(spark: SparkSession):
     class BaseTypeModel(SparkModel):
         a: int
         b: float
@@ -59,6 +60,10 @@ def test_base_type_fields():
 
     actual_schema = BaseTypeModel.model_spark_schema(by_alias=True)
     assert actual_schema == expected_schema
+
+    df = spark.createDataFrame([], schema=actual_schema)
+    ddl_schema = BaseTypeModel.model_ddl_spark_schema()
+    assert ddl_schema == df._jdf.schema().toDDL()
 
 
 def test_literal_fields():

--- a/tests/test_dict_types.py
+++ b/tests/test_dict_types.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 from typing import Dict, Union
 
 from pydantic import BaseModel
+from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     BinaryType,
     BooleanType,
@@ -22,7 +23,7 @@ from pyspark.sql.types import (
 from sparkdantic import SparkModel
 
 
-def test_dict_fields():
+def test_dict_fields(spark: SparkSession):
     class IntegerEnum(IntEnum):
         X = 1
         Y = 2
@@ -73,3 +74,7 @@ def test_dict_fields():
 
     actual_schema = DictModel.model_spark_schema()
     assert actual_schema == expected_schema
+
+    df = spark.createDataFrame([], schema=actual_schema)
+    ddl_schema = DictModel.model_ddl_spark_schema()
+    assert ddl_schema == df._jdf.schema().toDDL()

--- a/tests/test_enum_types.py
+++ b/tests/test_enum_types.py
@@ -1,13 +1,14 @@
 from enum import Enum, IntEnum
 
 import pytest
+from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 from sparkdantic import SparkModel
 from sparkdantic.exceptions import TypeConversionError
 
 
-def test_supported_enum_fields():
+def test_supported_enum_fields(spark: SparkSession):
     class IntegerEnum(IntEnum):
         X = 1
         Y = 2
@@ -28,6 +29,10 @@ def test_supported_enum_fields():
     )
     actual_schema = EnumModel.model_spark_schema()
     assert actual_schema == expected_schema
+
+    df = spark.createDataFrame([], schema=actual_schema)
+    ddl_schema = EnumModel.model_ddl_spark_schema()
+    assert ddl_schema == df._jdf.schema().toDDL()
 
 
 def test_unsupported_enum_type_raises_error():

--- a/tests/test_json_type_to_ddl.py
+++ b/tests/test_json_type_to_ddl.py
@@ -1,0 +1,22 @@
+import pytest
+
+from sparkdantic.model import _json_type_to_ddl
+
+
+def test_json_type_to_ddl_unknown_type():
+    """
+    Test the conversion of an unknown type to DDL.
+    """
+    # Define a mock JSON schema with an unknown type
+    json_schema = {
+        'type': 'unknown',
+        'properties': {
+            'field1': {'type': 'string'},
+            'field2': {'type': 'integer'},
+        },
+    }
+
+    # Call the function to convert JSON schema to DDL
+
+    with pytest.raises(TypeError, match='Unsupported JSON type: unknown'):
+        _json_type_to_ddl(json_schema)

--- a/tests/test_list_types.py
+++ b/tests/test_list_types.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 from typing import List, Optional, Union
 
 from pydantic import BaseModel
+from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -22,7 +23,7 @@ from pyspark.sql.types import (
 from sparkdantic import SparkModel
 
 
-def test_list_fields():
+def test_list_fields(spark: SparkSession):
     class IntegerEnum(IntEnum):
         X = 1
         Y = 2
@@ -85,3 +86,7 @@ def test_list_fields():
     )
     actual_schema = ListValuesModel.model_spark_schema()
     assert actual_schema == expected_schema
+
+    df = spark.createDataFrame([], schema=actual_schema)
+    ddl_schema = ListValuesModel.model_ddl_spark_schema()
+    assert ddl_schema == df._jdf.schema().toDDL()

--- a/tests/test_optional_types.py
+++ b/tests/test_optional_types.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from enum import IntEnum
 from typing import Optional
 
+from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     BinaryType,
     BooleanType,
@@ -20,7 +21,7 @@ from pyspark.sql.types import (
 from sparkdantic import SparkModel
 
 
-def test_optional_model_fields():
+def test_optional_model_fields(spark: SparkSession):
     class IntTestEnum(IntEnum):
         X = 1
         Y = 2
@@ -53,3 +54,7 @@ def test_optional_model_fields():
     )
     actual_schema = OptionalsModel.model_spark_schema()
     assert actual_schema == expected_schema
+
+    df = spark.createDataFrame([], schema=actual_schema)
+    ddl_schema = OptionalsModel.model_ddl_spark_schema()
+    assert ddl_schema == df._jdf.schema().toDDL()


### PR DESCRIPTION
Hi @mitchelllisle, The MR implements a `model_ddl_spark_schema()` method that generates DDL strings compatible with Spark's format. In pyspark, it's only possible to generate DDL strings from an existing DataFrame. This feature would be valuable for use cases requiring DDL strings without creating actual DataFrames first. Thoughts?