### PR TITLE
Added support for Pydantic HttpUrl type

### DIFF
--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -21,7 +21,16 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, SecretBytes, SecretStr
+from pydantic import (
+    AliasChoices,
+    AliasPath,
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    SecretBytes,
+    SecretStr,
+)
 from pydantic.fields import ComputedFieldInfo, FieldInfo
 from pydantic.json_schema import JsonSchemaMode
 
@@ -67,6 +76,7 @@ _type_mapping = MappingProxyType(
         Decimal: 'decimal',
         timedelta: 'interval day to second',
         UUID: 'string',
+        HttpUrl: 'string',
     }
 )
 

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from typing import Annotated, Literal, Optional
 from uuid import UUID
 
-from pydantic import Field, SecretBytes, SecretStr
+from pydantic import Field, HttpUrl, SecretBytes, SecretStr
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     BinaryType,
@@ -38,6 +38,7 @@ def test_base_type_fields(spark: SparkSession):
         jj: SecretStr
         x: str = Field(alias='_x')
         uuid: UUID
+        url: HttpUrl
 
     expected_schema = StructType(
         [
@@ -55,6 +56,7 @@ def test_base_type_fields(spark: SparkSession):
             StructField('jj', StringType(), False),
             StructField('_x', StringType(), False),
             StructField('uuid', StringType(), False),
+            StructField('url', StringType(), False),
         ]
     )
 


### PR DESCRIPTION
When I have a pydantic model with HttpUrl field I got the following error
```
E           TypeError: Type <class 'pydantic.networks.HttpUrl'> not recognized
```
and I mapped HttpUrl type to string to avoid this error