### PR TITLE
Support annotated return types for computed fields

### DIFF
--- a/src/sparkdantic/model.py
+++ b/src/sparkdantic/model.py
@@ -202,6 +202,11 @@ def create_json_spark_schema(
             name = _get_field_alias(name, info, mode)
 
         field_info_extra = info.json_schema_extra or {}
+        # Computed fields could have json_schema_extra on the return type:
+        if (not field_info_extra) and isinstance(info, ComputedFieldInfo):
+            rt = info.return_type
+            return_field_info = FieldInfo.from_annotation(rt)
+            field_info_extra = return_field_info.json_schema_extra or {}
         override = field_info_extra.get('spark_type')
         annotation_or_return_type = _get_annotation_or_return_type(info)
         field_type = _get_union_type_arg(annotation_or_return_type)

--- a/tests/test_computed_field.py
+++ b/tests/test_computed_field.py
@@ -109,3 +109,35 @@ def test_computed_field_with_spark_type():
     )
     actual_schema = create_spark_schema(ComputedWithSparkType, mode='serialization')
     assert actual_schema == expected_schema
+
+
+def test_computed_field_with_annotated_return_type():
+    class ComputedWithReturnSparkType(BaseModel):
+        @computed_field
+        @property
+        def d(self) -> Annotated[int, SparkField(spark_type=LongType)]:
+            return 4
+
+    expected_schema = StructType(
+        [
+            StructField('d', LongType(), False),
+        ]
+    )
+    actual_schema = create_spark_schema(ComputedWithReturnSparkType, mode='serialization')
+    assert actual_schema == expected_schema
+
+
+def test_computed_field_with_spark_type_over_annotated_return():
+    class ComputedWithSparkType(BaseModel):
+        @computed_field(json_schema_extra={"spark_type": LongType})
+        @property
+        def d(self) -> Annotated[int, SparkField(spark_type=StringType)]:
+            return 4
+
+    expected_schema = StructType(
+        [
+            StructField('d', LongType(), False),
+        ]
+    )
+    actual_schema = create_spark_schema(ComputedWithSparkType, mode='serialization')
+    assert actual_schema == expected_schema

--- a/tests/test_computed_field.py
+++ b/tests/test_computed_field.py
@@ -1,9 +1,9 @@
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import BaseModel, computed_field
-from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+from pyspark.sql.types import IntegerType, LongType, StringType, StructField, StructType
 
-from sparkdantic import create_spark_schema
+from sparkdantic import create_spark_schema, SparkField
 
 
 class ComputedOnlyModel(BaseModel):
@@ -92,4 +92,20 @@ def test_computed_field_with_return_type():
         ]
     )
     actual_schema = create_spark_schema(ComputedWithReturnType, mode='serialization')
+    assert actual_schema == expected_schema
+
+
+def test_computed_field_with_spark_type():
+    class ComputedWithSparkType(BaseModel):
+        @computed_field(json_schema_extra={"spark_type": LongType})
+        @property
+        def d(self) -> int:
+            return 4
+
+    expected_schema = StructType(
+        [
+            StructField('d', LongType(), False),
+        ]
+    )
+    actual_schema = create_spark_schema(ComputedWithSparkType, mode='serialization')
     assert actual_schema == expected_schema


### PR DESCRIPTION
There might be a better place to handle this but this fixes a surprise I had where annotated return types weren't being used for the spark schema