### PR TITLE
chore: bump version 2.8.1 -> 2.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/mitchelllisle/sparkdantic/graph/badge.svg?token=O6PPQX4FEX)](https://codecov.io/gh/mitchelllisle/sparkdantic)
 [![PyPI version](https://badge.fury.io/py/sparkdantic.svg)](https://badge.fury.io/py/sparkdantic)
 
-> 1️⃣ version: 2.8.1
+> 1️⃣ version: 2.8.2
 
 > ✍️ author: Mitchell Lisle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sparkdantic"
-version = "2.8.1"
+version = "2.8.2"
 description = "A pydantic -> spark schema library"
 readme = "README.md"
 requires-python = ">=3.10,<4.0.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.8.1
+current_version = 2.8.2
 commit = True
 tag = False
 

--- a/src/sparkdantic/__init__.py
+++ b/src/sparkdantic/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.8.1'
+__version__ = '2.8.2'
 __author__ = 'Mitchell Lisle'
 __email__ = 'm.lisle90@gmail.com'
 


### PR DESCRIPTION
Automated version bump for patch release v2.8.2.

Includes dependency updates from:
- #882: bump pymdown-extensions
- #883: bump idna

Release v2.8.2 has been tagged and published.